### PR TITLE
Add tracker oauth handling

### DIFF
--- a/src/.vuepress/TrackerOauthHandler.js
+++ b/src/.vuepress/TrackerOauthHandler.js
@@ -1,0 +1,42 @@
+const getStateFromQuery = (query) => {
+	const urlParams = new URLSearchParams(query);
+	return JSON.parse(urlParams.get("state"));
+};
+
+const getRedirectUrlFromQuery = (query = window.location.search) => {
+	const { redirectUrl } = getStateFromQuery(query);
+
+	if (!redirectUrl) {
+		throw new Error("No redirectUrl found");
+	}
+
+	return `${redirectUrl}${query}`;
+};
+
+const getRedirectUrlFromHash = () => {
+	const query = window.location.hash.replace("#", "?");
+	return getRedirectUrlFromQuery(query);
+};
+
+const getRedirectUrl = () => {
+	try {
+		return getRedirectUrlFromQuery();
+	} catch (e) {}
+
+	return getRedirectUrlFromHash();
+};
+
+export const setupTrackerOauthHandler = (router) => {
+	router.addRoute({
+		path: "/tracker-oauth",
+		beforeEnter() {
+			console.log("TrackerOauthHandler::handle: location", window.location);
+
+			try {
+				window.location.href = getRedirectUrl();
+			} catch (e) {
+				console.log("TrackerOauthHandler::handle: redirecting back to the client failed due to", e);
+			}
+		},
+	});
+};

--- a/src/.vuepress/enhanceApp.js
+++ b/src/.vuepress/enhanceApp.js
@@ -1,6 +1,7 @@
 import Element from "element-ui";
 import VueMoment from "vue-moment";
 import store from "./store";
+import { setupTrackerOauthHandler } from "./TrackerOauthHandler";
 
 export default ({
 	Vue, // the version of Vue being used in the VuePress app
@@ -11,4 +12,6 @@ export default ({
 	Vue.use(VueMoment);
 	Vue.use(Element);
 	Vue.mixin({ store });
+
+	setupTrackerOauthHandler(router);
 };


### PR DESCRIPTION
Due to the clients not having a static url, it is not possible to set a specific redirect url in each tracker client. Thus, instead, all trackers have to redirect to suwayomi.org which handles the redirection to the client